### PR TITLE
feat: update minimum deployment_target to 15.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:clix-ios-sdk}",
+            "name": "Debug BasicApp",
+            "program": "${workspaceFolder:clix-ios-sdk}/.build/debug/BasicApp",
+            "preLaunchTask": "swift: Build Debug BasicApp"
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:clix-ios-sdk}",
+            "name": "Release BasicApp",
+            "program": "${workspaceFolder:clix-ios-sdk}/.build/release/BasicApp",
+            "preLaunchTask": "swift: Build Release BasicApp"
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Compatibility**
+  - Updated minimum iOS deployment target from 14.0 to 15.0
+  - Updated Swift Package Manager platform requirement to iOS 15.0
+  - Updated CocoaPods deployment target to iOS 15.0
+
 ## [1.0.0] - 2025-06-01
 
 ### Added

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -10,7 +10,7 @@ Clix iOS SDK provides push notification and analytics capabilities for iOS apps.
   spec.license          = { :type => 'MIT', :file => 'LICENSE' }
   spec.author           = { 'Clix' => 'support@clix.so' }
   spec.source           = { :git => 'https://github.com/clix-so/clix-ios-sdk.git', :tag => spec.version.to_s }
-  spec.ios.deployment_target = '14.0'
+  spec.ios.deployment_target = '15.0'
   spec.swift_version = '5.5'
   spec.source_files = 'Sources/**/*'
   spec.frameworks = 'UIKit', 'UserNotifications'

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
   name: "Clix",
   platforms: [
-    .iOS(.v14)
+    .iOS(.v15)
   ],
   products: [
     .library(

--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ pod 'Clix'
 
 ## Requirements
 
-- iOS 14.0 or later
+- iOS 15.0 or later
 - Swift 5.5 or later
+
+## Breaking Changes
+
+### Firebase 12+ Support
+If you need to use Firebase 12 or later, you must use the latest version of Clix iOS SDK. Previous versions may not be compatible with Firebase 12+.
 
 ## Usage
 


### PR DESCRIPTION
To support the Firebase latest version, bump the minimum support iOS version to 15.0