### PR TITLE
feat: add user journey context to event properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,46 +4,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-09-04
+
+### Added
+
+- **Event Tracking**
+  - Added user journey context to event properties for statistics
+
 ## [1.1.1] - 2025-08-28
 
 ### Fixed
 
 - **Push Notifications**
-    - Fixed duplicate token processing issue that could cause unnecessary API calls
+  - Fixed duplicate token processing issue that could cause unnecessary API calls
 
 ## [1.1.0] - 2025-08-21
 
 ### Changed
 
 - **Compatibility**
-    - Updated minimum iOS deployment target from 14.0 to 15.0
-    - Updated Swift Package Manager platform requirement to iOS 15.0
-    - Updated CocoaPods deployment target to iOS 15.0
+  - Updated minimum iOS deployment target from 14.0 to 15.0
+  - Updated Swift Package Manager platform requirement to iOS 15.0
+  - Updated CocoaPods deployment target to iOS 15.0
 
 ## [1.0.0] - 2025-06-01
 
 ### Added
 
 - **Core SDK**
-    - ClixConfig-based initialization with projectId, apiKey, endpoint configuration
-    - Async/await and synchronous API support
-    - Thread-safe operations with automatic initialization handling
+
+  - ClixConfig-based initialization with projectId, apiKey, endpoint configuration
+  - Async/await and synchronous API support
+  - Thread-safe operations with automatic initialization handling
 
 - **User Management**
-    - User identification: `setUserId()`, `removeUserId()`
-    - User properties: `setUserProperty()`, `setUserProperties()`, `removeUserProperty()`
+
+  - User identification: `setUserId()`, `removeUserId()`
+  - User properties: `setUserProperty()`, `setUserProperties()`, `removeUserProperty()`
 
 - **Push Notifications**
-    - Firebase Cloud Messaging integration
-    - ClixAppDelegate for automated push notification handling
-    - ClixNotificationServiceExtension for rich notifications with images
-    - Automatic device token management
+
+  - Firebase Cloud Messaging integration
+  - ClixAppDelegate for automated push notification handling
+  - ClixNotificationServiceExtension for rich notifications with images
+  - Automatic device token management
 
 - **Device & Logging**
-    - Device information access: `getDeviceId()`, `getPushToken()`
-    - Configurable logging system with 5 levels (none to debug)
+
+  - Device information access: `getDeviceId()`, `getPushToken()`
+  - Configurable logging system with 5 levels (none to debug)
 
 - **Installation**
-    - Swift Package Manager and CocoaPods support
-    - iOS 14.0+ and Swift 5.5+ compatibility
-    - Sample app with complete integration example
+  - Swift Package Manager and CocoaPods support
+  - iOS 14.0+ and Swift 5.5+ compatibility
+  - Sample app with complete integration example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,52 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Event Tracking**
-  - Added user journey context to event properties for statistics
+    - Added user journey context to event properties for statistics
 
 ## [1.1.1] - 2025-08-28
 
 ### Fixed
 
 - **Push Notifications**
-  - Fixed duplicate token processing issue that could cause unnecessary API calls
+    - Fixed duplicate token processing issue that could cause unnecessary API calls
 
 ## [1.1.0] - 2025-08-21
 
 ### Changed
 
 - **Compatibility**
-  - Updated minimum iOS deployment target from 14.0 to 15.0
-  - Updated Swift Package Manager platform requirement to iOS 15.0
-  - Updated CocoaPods deployment target to iOS 15.0
+    - Updated minimum iOS deployment target from 14.0 to 15.0
+    - Updated Swift Package Manager platform requirement to iOS 15.0
+    - Updated CocoaPods deployment target to iOS 15.0
 
 ## [1.0.0] - 2025-06-01
 
 ### Added
 
 - **Core SDK**
-
-  - ClixConfig-based initialization with projectId, apiKey, endpoint configuration
-  - Async/await and synchronous API support
-  - Thread-safe operations with automatic initialization handling
+    - ClixConfig-based initialization with projectId, apiKey, endpoint configuration
+    - Async/await and synchronous API support
+    - Thread-safe operations with automatic initialization handling
 
 - **User Management**
-
-  - User identification: `setUserId()`, `removeUserId()`
-  - User properties: `setUserProperty()`, `setUserProperties()`, `removeUserProperty()`
+    - User identification: `setUserId()`, `removeUserId()`
+    - User properties: `setUserProperty()`, `setUserProperties()`, `removeUserProperty()`
 
 - **Push Notifications**
-
-  - Firebase Cloud Messaging integration
-  - ClixAppDelegate for automated push notification handling
-  - ClixNotificationServiceExtension for rich notifications with images
-  - Automatic device token management
+    - Firebase Cloud Messaging integration
+    - ClixAppDelegate for automated push notification handling
+    - ClixNotificationServiceExtension for rich notifications with images
+    - Automatic device token management
 
 - **Device & Logging**
-
-  - Device information access: `getDeviceId()`, `getPushToken()`
-  - Configurable logging system with 5 levels (none to debug)
+    - Device information access: `getDeviceId()`, `getPushToken()`
+    - Configurable logging system with 5 levels (none to debug)
 
 - **Installation**
-  - Swift Package Manager and CocoaPods support
-  - iOS 14.0+ and Swift 5.5+ compatibility
-  - Sample app with complete integration example
+    - Swift Package Manager and CocoaPods support
+    - iOS 14.0+ and Swift 5.5+ compatibility
+    - Sample app with complete integration example

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.1.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.2.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.1.1"
+  internal static let current: String = "1.2.0"
 }

--- a/Sources/Services/EventAPIService.swift
+++ b/Sources/Services/EventAPIService.swift
@@ -4,14 +4,14 @@ import Foundation
 struct EventRequestBody: Codable {
   let device_id: String
   let name: String
-  let event_property: [String: AnyCodable]  // expects ["custom_properties": ...]
+  let properties: [String: AnyCodable]  // expects ["custom_properties": ...]
 }
 
 struct EventResponseBody: Codable {
   let user_id: String?
   let device_id: String
   let name: String
-  let event_property: [String: AnyCodable]
+  let properties: [String: AnyCodable]
 }
 
 struct EventsResponse: Codable {
@@ -24,14 +24,19 @@ class EventAPIService: ClixAPIClient {
     deviceId: String,
     name: String,
     properties: [String: AnyCodable]? = nil,
-    messageId: String? = nil
+    messageId: String? = nil,
+    userJourneyId: String? = nil,
+    userJourneyNodeId: String? = nil
   )
     async throws
   {
     let event = EventRequestBody(
       device_id: deviceId,
       name: name,
-      event_property: ["custom_properties": AnyCodable(properties ?? [:]), "message_id": AnyCodable(messageId)]
+      properties: [
+        "custom_properties": AnyCodable(properties ?? [:]), "message_id": AnyCodable(messageId),
+        "user_journey_id": AnyCodable(userJourneyId), "user_journey_node_id": AnyCodable(userJourneyNodeId),
+      ]
     )
     let path = "/events"
     let body = ["events": [event]]

--- a/Sources/Services/EventService.swift
+++ b/Sources/Services/EventService.swift
@@ -3,12 +3,25 @@ import Foundation
 class EventService {
   private let apiService = EventAPIService()
 
-  func trackEvent(name: String, properties: [String: Any?] = [:], messageId: String? = nil) async throws {
+  func trackEvent(
+    name: String,
+    properties: [String: Any?] = [:],
+    messageId: String? = nil,
+    userJourneyId: String? = nil,
+    userJourneyNodeId: String? = nil
+  ) async throws {
     do {
       let environment = try Clix.shared.get(\.environment)
       let deviceId = environment.getDevice().id
       let eventProperties = properties.compactMapValues { $0 }.mapValues { AnyCodable($0) }
-      try await apiService.trackEvent(deviceId: deviceId, name: name, properties: eventProperties, messageId: messageId)
+      try await apiService.trackEvent(
+        deviceId: deviceId,
+        name: name,
+        properties: eventProperties,
+        messageId: messageId,
+        userJourneyId: userJourneyId,
+        userJourneyNodeId: userJourneyNodeId
+      )
     } catch {
       ClixLogger.error("Failed to track event '\(name)': \(error). Make sure Clix.initialize() has been called.")
       throw error

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -8,6 +8,11 @@ private struct NotificationSettings: Codable {
   var lastUpdated: Date
 }
 
+enum NotificationEvent: String {
+  case PUSH_NOTIFICATION_RECEIVED = "PUSH_NOTIFICATION_RECEIVED"
+  case PUSH_NOTIFICATION_TAPPED = "PUSH_NOTIFICATION_TAPPED"
+}
+
 class NotificationService {
   private let eventService: EventService
   private let storageService: StorageService
@@ -27,13 +32,13 @@ class NotificationService {
       Task {
         do {
           try await eventService.trackEvent(
-            name: "PUSH_NOTIFICATION_RECEIVED",
+            name: NotificationEvent.PUSH_NOTIFICATION_RECEIVED.rawValue,
             messageId: messageId,
             userJourneyId: userJourneyId,
             userJourneyNodeId: userJourneyNodeId
           )
         } catch {
-          ClixLogger.error("Failed to track PUSH_NOTIFICATION_RECEIVED", error: error)
+          ClixLogger.error("Failed to track \(NotificationEvent.PUSH_NOTIFICATION_RECEIVED.rawValue)", error: error)
         }
       }
     } else {
@@ -49,13 +54,13 @@ class NotificationService {
       Task {
         do {
           try await eventService.trackEvent(
-            name: "PUSH_NOTIFICATION_TAPPED",
+            name: NotificationEvent.PUSH_NOTIFICATION_TAPPED.rawValue,
             messageId: messageId,
             userJourneyId: userJourneyId,
             userJourneyNodeId: userJourneyNodeId
           )
         } catch {
-          ClixLogger.error("Failed to track PUSH_NOTIFICATION_TAPPED", error: error)
+          ClixLogger.error("Failed to track \(NotificationEvent.PUSH_NOTIFICATION_TAPPED.rawValue)", error: error)
         }
       }
     } else {

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -21,9 +21,17 @@ class NotificationService {
 
   func handlePushReceived(userInfo: [AnyHashable: Any]) {
     if let messageId = getMessageId(userInfo: userInfo) {
+      let userJourneyId = getUserJourneyId(userInfo: userInfo)
+      let userJourneyNodeId = getUserJourneyNodeId(userInfo: userInfo)
+
       Task {
         do {
-          try await eventService.trackEvent(name: "PUSH_NOTIFICATION_RECEIVED", messageId: messageId)
+          try await eventService.trackEvent(
+            name: "PUSH_NOTIFICATION_RECEIVED",
+            messageId: messageId,
+            userJourneyId: userJourneyId,
+            userJourneyNodeId: userJourneyNodeId
+          )
         } catch {
           ClixLogger.error("Failed to track PUSH_NOTIFICATION_RECEIVED", error: error)
         }
@@ -35,9 +43,17 @@ class NotificationService {
 
   func handlePushTapped(userInfo: [AnyHashable: Any]) {
     if let messageId = getMessageId(userInfo: userInfo) {
+      let userJourneyId = getUserJourneyId(userInfo: userInfo)
+      let userJourneyNodeId = getUserJourneyNodeId(userInfo: userInfo)
+
       Task {
         do {
-          try await eventService.trackEvent(name: "PUSH_NOTIFICATION_TAPPED", messageId: messageId)
+          try await eventService.trackEvent(
+            name: "PUSH_NOTIFICATION_TAPPED",
+            messageId: messageId,
+            userJourneyId: userJourneyId,
+            userJourneyNodeId: userJourneyNodeId
+          )
         } catch {
           ClixLogger.error("Failed to track PUSH_NOTIFICATION_TAPPED", error: error)
         }
@@ -52,6 +68,26 @@ class NotificationService {
       let messageId = clixData["message_id"] as? String
     {
       return messageId
+    }
+
+    return nil
+  }
+
+  private func getUserJourneyId(userInfo: [AnyHashable: Any]) -> String? {
+    if let clixData = parseClixPayload(from: userInfo),
+      let userJourneyId = clixData["user_journey_id"] as? String
+    {
+      return userJourneyId
+    }
+
+    return nil
+  }
+
+  private func getUserJourneyNodeId(userInfo: [AnyHashable: Any]) -> String? {
+    if let clixData = parseClixPayload(from: userInfo),
+      let userJourneyNodeId = clixData["user_journey_node_id"] as? String
+    {
+      return userJourneyNodeId
     }
 
     return nil

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -9,8 +9,8 @@ private struct NotificationSettings: Codable {
 }
 
 enum NotificationEvent: String {
-  case PUSH_NOTIFICATION_RECEIVED = "PUSH_NOTIFICATION_RECEIVED"
-  case PUSH_NOTIFICATION_TAPPED = "PUSH_NOTIFICATION_TAPPED"
+  case pushNotificationReceived = "PUSH_NOTIFICATION_RECEIVED"
+  case pushNotificationTapped = "PUSH_NOTIFICATION_TAPPED"
 }
 
 class NotificationService {
@@ -32,13 +32,13 @@ class NotificationService {
       Task {
         do {
           try await eventService.trackEvent(
-            name: NotificationEvent.PUSH_NOTIFICATION_RECEIVED.rawValue,
+            name: NotificationEvent.pushNotificationReceived.rawValue,
             messageId: messageId,
             userJourneyId: userJourneyId,
             userJourneyNodeId: userJourneyNodeId
           )
         } catch {
-          ClixLogger.error("Failed to track \(NotificationEvent.PUSH_NOTIFICATION_RECEIVED.rawValue)", error: error)
+          ClixLogger.error("Failed to track \(NotificationEvent.pushNotificationReceived.rawValue)", error: error)
         }
       }
     } else {
@@ -54,13 +54,13 @@ class NotificationService {
       Task {
         do {
           try await eventService.trackEvent(
-            name: NotificationEvent.PUSH_NOTIFICATION_TAPPED.rawValue,
+            name: NotificationEvent.pushNotificationTapped.rawValue,
             messageId: messageId,
             userJourneyId: userJourneyId,
             userJourneyNodeId: userJourneyNodeId
           )
         } catch {
-          ClixLogger.error("Failed to track \(NotificationEvent.PUSH_NOTIFICATION_TAPPED.rawValue)", error: error)
+          ClixLogger.error("Failed to track \(NotificationEvent.pushNotificationTapped.rawValue)", error: error)
         }
       }
     } else {


### PR DESCRIPTION
- `PUSH_NOTIFICATION_RECEIVED`, `PUSH_NOTIFICATION_TAPPED` 이벤트를 로깅할 때 `properties`에 `user_journey_id`, `user_journey_node_id` 추가합니다.