### PR TITLE
fix: ensure push token issued regardless of permission

### DIFF
--- a/Clix.xcworkspace/contents.xcworkspacedata
+++ b/Clix.xcworkspace/contents.xcworkspacedata
@@ -50,6 +50,9 @@
          <FileRef
             location = "group:ClixEnvironment.swift">
          </FileRef>
+         <FileRef
+            location = "group:ClixNotification.swift">
+         </FileRef>
       </Group>
       <Group
          location = "group:Notification"

--- a/Samples/BasicApp/Sources/ContentView.swift
+++ b/Samples/BasicApp/Sources/ContentView.swift
@@ -11,13 +11,13 @@ struct ContentView: View {
 
   @State private var eventNameInput: String = "test"
   @State private var eventParamsInput: String = """
-  {
-    "string": "string",
-    "number": 1.5,
-    "boolean": true,
-    "object": { "key": "value" }
-  }
-  """
+    {
+      "string": "string",
+      "number": 1.5,
+      "boolean": true,
+      "object": { "key": "value" }
+    }
+    """
 
   @State private var showAlert: Bool = false
   @State private var alertMessage: String = ""

--- a/Sources/Core/Clix.swift
+++ b/Sources/Core/Clix.swift
@@ -157,6 +157,7 @@ public final class Clix {
       shared.setEnvironment(environment)
 
       try await shared.get(\.storageService).set(Self.configKey, config)
+      try await shared.get(\.deviceService).upsertDevice(device)
 
       ClixLogger.debug("Clix SDK initialized with environment: \(environment.toString())")
 

--- a/Sources/Core/ClixNotification.swift
+++ b/Sources/Core/ClixNotification.swift
@@ -29,7 +29,16 @@ public class ClixNotification: NSObject, UNUserNotificationCenterDelegate, Messa
     if UNUserNotificationCenter.current().delegate == nil {
       UNUserNotificationCenter.current().delegate = self
     }
-    if autoRequestAuthorization { requestAndRegisterForNotifications() }
+
+    DispatchQueue.main.async {
+      UIApplication.shared.registerForRemoteNotifications()
+    }
+
+    if autoRequestAuthorization {
+      UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+        if let error = error { ClixLogger.error("Failed to request notification authorization", error: error) }
+      }
+    }
     setupAppStateNotifications()
   }
 
@@ -303,15 +312,6 @@ public class ClixNotification: NSObject, UNUserNotificationCenterDelegate, Messa
       } catch {
         ClixLogger.error("Failed to download image for notification", error: error)
       }
-    }
-  }
-
-  private func requestAndRegisterForNotifications() {
-    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-      if granted {
-        DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
-      }
-      if let error = error { ClixLogger.error("Failed to request notification authorization", error: error) }
     }
   }
 

--- a/Sources/Services/DeviceService.swift
+++ b/Sources/Services/DeviceService.swift
@@ -57,7 +57,7 @@ actor DeviceService {
 
   func upsertDevice(_ device: ClixDevice) async throws {
     ClixLogger.debug("upsertDevice: \(device)")
-    
+
     try await deviceApiService.upsertDevice(device: device)
   }
 

--- a/Sources/Services/EventService.swift
+++ b/Sources/Services/EventService.swift
@@ -21,11 +21,10 @@ class EventService {
       let eventProperties = properties.compactMapValues { $0 }.mapValues { value -> AnyCodable in
         switch value {
         case let number as NSNumber:
-          if number.isBool {
-            return AnyCodable(number.boolValue)
-          } else {
+          guard number.isBool else {
             return AnyCodable(number.doubleValue)
           }
+          return AnyCodable(number.boolValue)
         case let string as String:
           return AnyCodable(string)
         case let date as Date:
@@ -35,7 +34,7 @@ class EventService {
           return AnyCodable(String(describing: value))
         }
       }
-      
+
       try await apiService.trackEvent(
         deviceId: deviceId,
         name: name,

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -253,23 +253,6 @@ class NotificationService {
     await storageService.get(settingsKey)
   }
 
-  func requestNotificationPermission() async throws {
-    let granted = try await UNUserNotificationCenter.current()
-      .requestAuthorization(options: [.alert, .sound, .badge])
-    if granted {
-      await MainActor.run {
-        UIApplication.shared.registerForRemoteNotifications()
-      }
-    }
-
-    let settings = NotificationSettings(
-      enabled: granted,
-      categories: nil,
-      lastUpdated: Date()
-    )
-    await storageService.set(settingsKey, settings)
-  }
-
   func reset() async {
     await storageService.remove(settingsKey)
     await storageService.remove(lastNotificationKey)

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -253,6 +253,22 @@ class NotificationService {
     await storageService.get(settingsKey)
   }
 
+  func requestNotificationPermission() async throws {
+    ClixLogger.debug("Requesting notification permission")
+    let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+    ClixLogger.debug("Notification permission \(granted ? "granted": "denied")")
+
+    let settings = NotificationSettings(
+      enabled: granted,
+      categories: nil,
+      lastUpdated: Date()
+    )
+    await storageService.set(settingsKey, settings)
+    let deviceService = try await Clix.shared.getWithWait(\.deviceService)
+    try await deviceService.upsertIsPushPermissionGranted(granted)
+    ClixLogger.debug("Push permission synced to server")
+  }
+
   func reset() async {
     await storageService.remove(settingsKey)
     await storageService.remove(lastNotificationKey)


### PR DESCRIPTION
# Summary

- Ensure that the `push_token` is issued regardless of whether push notifications are allowed.
- Change the timing of device updates so that device-related information is updated as early as possible:
  - Device info, SDK info, Last Session time
  - Push token
  - Push permission granted

## Device Update Timing

### 1. In `Clix.initialize()`
- Use the `push_token` value stored in local storage.
- Use `is_push_permission_granted` derived from `settings.authorizationStatus`.

### 2. In `MessagingDelegate` (FCM token update callback)
```swift
public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
  ...
  try await processToken(token, tokenType: "FCM")
  ...
}
```
- Since this callback is triggered every time the app launches—even when the FCM token hasn’t changed—prevent excessive `upsert` calls by skipping when the new token matches the existing `device.pushToken`.
```swift
func upsertToken(_ token: String, tokenType: String = pushTokenTypeFCM) async throws {
  let environment = try Clix.shared.get(\.environment)
  let device = environment.getDevice()

  if (device.pushToken == token && device.pushTokenType == tokenType) {
    ClixLogger.debug("Token already exists, skipping upsert")
    return
  }

  // ... API call
}
```

### 3. In `requestAuthorization` callback (executed when the user responds to the notification permission popup)
```swift
private func requestNotificationAuthorization() {
  UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { [weak self] granted, error in
    ...
    try await self?.processPushPermission(granted)
    ...
  }
}
```
- Since this callback also runs each time the app launches—even if the permission value hasn’t changed—prevent excessive `upsert` calls by skipping when the new value matches the existing `device.isPushPermissionGranted`.
```swift
func upsertIsPushPermissionGranted(_ isPushPermissionGranted: Bool) async throws {
  let environment = try Clix.shared.get(\.environment)
  let device = environment.getDevice()

  if (device.isPushPermissionGranted == isPushPermissionGranted) {
    ClixLogger.debug("Push permission already exists, skipping upsert")
    return
  }

  // ... API call
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Streamlined notification permission flow with clearer prompts, persisted choice, and automatic server sync.
- Refactor
  - Device registration now syncs during app startup for more reliable setup.
  - Optimized push token and permission handling to avoid redundant updates and reduce unnecessary network calls.
  - Separated notification authorization from remote-registration to improve stability and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->