### PR TITLE
fix: deduplicate push received tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Push Notifications**
-    - Prevented duplicate `PUSH_NOTIFICATION_RECEIVED` tracking when both the notification service extension and application process handle the same message id.
+  - Prevented duplicate `PUSH_NOTIFICATION_RECEIVED` tracking when both the notification service extension and application process handle the same message id.
 
 ## [1.4.0] - 2025-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2025-10-18
+
+### Fixed
+
+- **Push Notifications**
+    - Prevented duplicate `PUSH_NOTIFICATION_RECEIVED` tracking when both the notification service extension and application process handle the same message id.
+
 ## [1.4.0] - 2025-10-15
 
 ### Added

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.4.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.4.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/Samples/BasicApp/Sources/AppDelegate.swift
+++ b/Samples/BasicApp/Sources/AppDelegate.swift
@@ -25,12 +25,12 @@ class AppDelegate: ClixAppDelegate {
       print("✅ Set user_id from UserDefaults: \(savedUserId)")
     }
 
-    Messaging.messaging().token { token, error in
-      if let error = error {
-        print("❌ Error fetching FCM registration token: \(error)")
-      } else if let _ = token {
-        self.updateClixValues()
-      }
+    NotificationCenter.default.addObserver(
+      forName: .MessagingRegistrationTokenRefreshed,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.updateClixValues()
     }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
@@ -61,8 +61,10 @@ class AppDelegate: ClixAppDelegate {
       let deviceId = await Clix.getDeviceId()
       let fcmToken = await Clix.getPushToken()
 
+      await MainActor.run {
       AppState.shared.updateDeviceId(deviceId)
       AppState.shared.updateFCMToken(fcmToken)
+      }
 
       print("🔄 Updated AppState - Device ID: \(deviceId ?? "nil"), FCM Token: \(fcmToken ?? "nil")")
     }

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.4.0"
+  internal static let current: String = "1.4.1"
 }


### PR DESCRIPTION
  - guard PUSH_NOTIFICATION_RECEIVED tracking by caching the last received message id and skipping duplicates when both NSE and the app process handle the same payload
  - clear the cached message id if tracking fails so a retry can occur
  - update the sample app to point at the current dev endpoint with required access token and default credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate push notification tracking when the same notification is processed by both the service extension and the app; added message-ID deduplication.

* **Improvements**
  * Made FCM token refresh handling event-driven and improved main-thread state synchronization for more reliable updates.

* **Chores**
  * Bumped release version to 1.4.1 and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->