### PR TITLE
chore: update user property value field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-11-17
+
+### Changed
+
+- Updated internal payload structure for improved data handling
+
 ## [1.5.0] - 2025-11-17
 
 ### Added

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.5.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.5.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clix iOS SDK is a powerful tool for managing push notifications and user events 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.0.0")
+    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.5.1")
 ]
 ```
 

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.5.0"
+  internal static let current: String = "1.5.1"
 }

--- a/Sources/Models/ClixUserProperty.swift
+++ b/Sources/Models/ClixUserProperty.swift
@@ -9,12 +9,12 @@ public struct ClixUserProperty: Codable {
   }
 
   public let name: String
-  public let value_string: AnyCodable  // swiftlint:disable:this identifier_name
+  public let value: AnyCodable  // swiftlint:disable:this identifier_name
   public let type: PropertyType
 
   public init(name: String, value: AnyCodable, type: PropertyType) {
     self.name = name
-    self.value_string = value
+    self.value = value
     self.type = type
   }
 


### PR DESCRIPTION
* renamed `value_string` field to `value` in `ClixUserProperty` model to match with backend idl update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.5.1

* **Changes**
  * Updated internal payload structure for improved data handling
  * Simplified user property field naming for better API usability

* **Chores**
  * Version updated to 1.5.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->