### PR TITLE
feat: add Live Activity support with push-to-start tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Read Changelog
         id: read_changelog
-        if: ${{ !endsWith(github.event.inputs.version, 'SNAPSHOT') }}
+        if: ${{ !contains(github.event.inputs.version, 'beta') && !endsWith(github.event.inputs.version, 'SNAPSHOT') }}
         uses: mindsers/changelog-reader-action@v2
         with:
           version: ${{ github.event.inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-01-16
+
+### Added
+
+- **Live Activity**
+  - Added `Clix.LiveActivity` for Live Activity push-to-start token management (iOS 17.2+)
+  - Automatically listens for push-to-start tokens and syncs with backend
+  - Usage: `Clix.LiveActivity.setup(YourActivityAttributes.self)`
+
 ## [1.6.0] - 2025-12-03
 
 ### Added

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.7.0-beta.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.7.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.6.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.7.0-beta.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clix iOS SDK is a powerful tool for managing push notifications and user events 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.7.0-beta.1")
+    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.7.0")
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clix iOS SDK is a powerful tool for managing push notifications and user events 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.6.0")
+    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.7.0-beta.1")
 ]
 ```
 

--- a/Samples/BasicApp/BasicApp-Info.plist
+++ b/Samples/BasicApp/BasicApp-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+		<key>NSSupportsLiveActivities</key>
+		<true/>
 		<key>UIBackgroundModes</key>
 		<array>
 			<string>remote-notification</string>

--- a/Samples/BasicApp/BasicApp.xcodeproj/project.pbxproj
+++ b/Samples/BasicApp/BasicApp.xcodeproj/project.pbxproj
@@ -8,11 +8,23 @@
 
 /* Begin PBXBuildFile section */
 		481BED572DDF9B7E00C3637B /* Clix in Frameworks */ = {isa = PBXBuildFile; productRef = 481BED562DDF9B7E00C3637B /* Clix */; };
+		7FADBC0A2F15FA9C0065D721 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FADBC092F15FA9B0065D721 /* WidgetKit.framework */; };
+		7FADBC0C2F15FA9C0065D721 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FADBC0B2F15FA9C0065D721 /* SwiftUI.framework */; };
+		7FADBC1B2F15FA9D0065D721 /* DeliveryLiveActivityWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7FADBC082F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		7FADBC262F15FD6A0065D721 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7FADBC252F15FD6A0065D721 /* GoogleService-Info.plist */; };
+		7FADBC282F15FD790065D721 /* ClixConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 7FADBC272F15FD790065D721 /* ClixConfig.json */; };
 		88C976AF2DE72BA500D410F8 /* ClixNotificationExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 88C976A82DE72BA500D410F8 /* ClixNotificationExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		88C976B82DE7426200D410F8 /* Clix in Frameworks */ = {isa = PBXBuildFile; productRef = 88C976B72DE7426200D410F8 /* Clix */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		7FADBC192F15FA9D0065D721 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 48F08EBD2DDF90CC003D26D4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7FADBC072F15FA9B0065D721;
+			remoteInfo = DeliveryLiveActivityWidgetExtension;
+		};
 		88C976AD2DE72BA500D410F8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 48F08EBD2DDF90CC003D26D4 /* Project object */;
@@ -30,6 +42,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				88C976AF2DE72BA500D410F8 /* ClixNotificationExtension.appex in Embed Foundation Extensions */,
+				7FADBC1B2F15FA9D0065D721 /* DeliveryLiveActivityWidgetExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -40,23 +53,35 @@
 		48533B3D2DE436D80060D148 /* BasicApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BasicApp.entitlements; sourceTree = "<group>"; };
 		48533B3E2DE437020060D148 /* BasicApp-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "BasicApp-Info.plist"; sourceTree = "<group>"; };
 		48F08EC52DDF90CC003D26D4 /* BasicApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BasicApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7FADBC082F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DeliveryLiveActivityWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		7FADBC092F15FA9B0065D721 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		7FADBC0B2F15FA9C0065D721 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		7FADBC252F15FD6A0065D721 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		7FADBC272F15FD790065D721 /* ClixConfig.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ClixConfig.json; sourceTree = "<group>"; };
 		88C976A82DE72BA500D410F8 /* ClixNotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ClixNotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		4841A3192ED6D8E90012881F /* Exceptions for "Resources" folder in "ClixNotificationExtension" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				ClixConfig.json,
-			);
-			target = 88C976A72DE72BA500D410F8 /* ClixNotificationExtension */;
-		};
 		488227102DFA764A0072376D /* Exceptions for "Sources" folder in "ClixNotificationExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				ClixConfiguration.swift,
 			);
 			target = 88C976A72DE72BA500D410F8 /* ClixNotificationExtension */;
+		};
+		7FADBC1E2F15FA9D0065D721 /* Exceptions for "DeliveryLiveActivityWidget" folder in "DeliveryLiveActivityWidgetExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7FADBC072F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension */;
+		};
+		7FADBC242F15FAD50065D721 /* Exceptions for "Sources" folder in "DeliveryLiveActivityWidgetExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				DeliveryActivityAttributes.swift,
+			);
+			target = 7FADBC072F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension */;
 		};
 		88C976B32DE72BA500D410F8 /* Exceptions for "ClixNotificationExtension" folder in "ClixNotificationExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -70,9 +95,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		489A1DF02DF6B864005D66F7 /* Resources */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				4841A3192ED6D8E90012881F /* Exceptions for "Resources" folder in "ClixNotificationExtension" target */,
-			);
 			path = Resources;
 			sourceTree = "<group>";
 		};
@@ -80,8 +102,17 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				488227102DFA764A0072376D /* Exceptions for "Sources" folder in "ClixNotificationExtension" target */,
+				7FADBC242F15FAD50065D721 /* Exceptions for "Sources" folder in "DeliveryLiveActivityWidgetExtension" target */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		7FADBC0D2F15FA9C0065D721 /* DeliveryLiveActivityWidget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7FADBC1E2F15FA9D0065D721 /* Exceptions for "DeliveryLiveActivityWidget" folder in "DeliveryLiveActivityWidgetExtension" target */,
+			);
+			path = DeliveryLiveActivityWidget;
 			sourceTree = "<group>";
 		};
 		88C976A92DE72BA500D410F8 /* ClixNotificationExtension */ = {
@@ -103,6 +134,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7FADBC052F15FA9B0065D721 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7FADBC0C2F15FA9C0065D721 /* SwiftUI.framework in Frameworks */,
+				7FADBC0A2F15FA9C0065D721 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		88C976A52DE72BA500D410F8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -117,11 +157,14 @@
 		48F08EBC2DDF90CC003D26D4 = {
 			isa = PBXGroup;
 			children = (
+				7FADBC272F15FD790065D721 /* ClixConfig.json */,
+				7FADBC252F15FD6A0065D721 /* GoogleService-Info.plist */,
 				489A1DF02DF6B864005D66F7 /* Resources */,
 				48533B3E2DE437020060D148 /* BasicApp-Info.plist */,
 				48533B3D2DE436D80060D148 /* BasicApp.entitlements */,
 				48F08EC72DDF90CC003D26D4 /* Sources */,
 				88C976A92DE72BA500D410F8 /* ClixNotificationExtension */,
+				7FADBC0D2F15FA9C0065D721 /* DeliveryLiveActivityWidget */,
 				48F08EC62DDF90CC003D26D4 /* Products */,
 				88C976B62DE7426200D410F8 /* Frameworks */,
 			);
@@ -132,6 +175,7 @@
 			children = (
 				48F08EC52DDF90CC003D26D4 /* BasicApp.app */,
 				88C976A82DE72BA500D410F8 /* ClixNotificationExtension.appex */,
+				7FADBC082F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -139,6 +183,8 @@
 		88C976B62DE7426200D410F8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7FADBC092F15FA9B0065D721 /* WidgetKit.framework */,
+				7FADBC0B2F15FA9C0065D721 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -159,6 +205,7 @@
 			);
 			dependencies = (
 				88C976AE2DE72BA500D410F8 /* PBXTargetDependency */,
+				7FADBC1A2F15FA9D0065D721 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				489A1DF02DF6B864005D66F7 /* Resources */,
@@ -171,6 +218,28 @@
 			productName = BasicApp;
 			productReference = 48F08EC52DDF90CC003D26D4 /* BasicApp.app */;
 			productType = "com.apple.product-type.application";
+		};
+		7FADBC072F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7FADBC1F2F15FA9D0065D721 /* Build configuration list for PBXNativeTarget "DeliveryLiveActivityWidgetExtension" */;
+			buildPhases = (
+				7FADBC042F15FA9B0065D721 /* Sources */,
+				7FADBC052F15FA9B0065D721 /* Frameworks */,
+				7FADBC062F15FA9B0065D721 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				7FADBC0D2F15FA9C0065D721 /* DeliveryLiveActivityWidget */,
+			);
+			name = DeliveryLiveActivityWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = DeliveryLiveActivityWidgetExtension;
+			productReference = 7FADBC082F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		88C976A72DE72BA500D410F8 /* ClixNotificationExtension */ = {
 			isa = PBXNativeTarget;
@@ -202,11 +271,14 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1620;
+				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					48F08EC42DDF90CC003D26D4 = {
 						CreatedOnToolsVersion = 16.3;
+					};
+					7FADBC072F15FA9B0065D721 = {
+						CreatedOnToolsVersion = 16.4;
 					};
 					88C976A72DE72BA500D410F8 = {
 						CreatedOnToolsVersion = 16.2;
@@ -232,12 +304,22 @@
 			targets = (
 				48F08EC42DDF90CC003D26D4 /* BasicApp */,
 				88C976A72DE72BA500D410F8 /* ClixNotificationExtension */,
+				7FADBC072F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		48F08EC32DDF90CC003D26D4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7FADBC262F15FD6A0065D721 /* GoogleService-Info.plist in Resources */,
+				7FADBC282F15FD790065D721 /* ClixConfig.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7FADBC062F15FA9B0065D721 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -261,6 +343,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7FADBC042F15FA9B0065D721 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		88C976A42DE72BA500D410F8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -271,6 +360,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		7FADBC1A2F15FA9D0065D721 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7FADBC072F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension */;
+			targetProxy = 7FADBC192F15FA9D0065D721 /* PBXContainerItemProxy */;
+		};
 		88C976AE2DE72BA500D410F8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 88C976A72DE72BA500D410F8 /* ClixNotificationExtension */;
@@ -464,6 +558,62 @@
 			};
 			name = Release;
 		};
+		7FADBC1C2F15FA9D0065D721 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DeliveryLiveActivityWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = DeliveryLiveActivityWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = so.clix.samples.basic.DeliveryLiveActivityWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7FADBC1D2F15FA9D0065D721 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DeliveryLiveActivityWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = DeliveryLiveActivityWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = so.clix.samples.basic.DeliveryLiveActivityWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		88C976B12DE72BA500D410F8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -533,6 +683,15 @@
 			buildConfigurations = (
 				48F08ED12DDF90CD003D26D4 /* Debug */,
 				48F08ED22DDF90CD003D26D4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7FADBC1F2F15FA9D0065D721 /* Build configuration list for PBXNativeTarget "DeliveryLiveActivityWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7FADBC1C2F15FA9D0065D721 /* Debug */,
+				7FADBC1D2F15FA9D0065D721 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/Contents.json
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidget.swift
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidget.swift
@@ -1,0 +1,87 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct DeliveryLiveActivityWidget: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: DeliveryActivityAttributes.self) { context in
+      // Lock screen / banner UI
+      VStack(alignment: .leading, spacing: 8) {
+        HStack {
+          Image(systemName: "bag.fill")
+            .foregroundColor(.orange)
+          Text(context.attributes.restaurantName)
+            .font(.headline)
+            .fontWeight(.semibold)
+          Spacer()
+          Text("Order #\(context.attributes.orderNumber)")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+
+        HStack {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(context.state.status)
+              .font(.subheadline)
+              .fontWeight(.medium)
+            Text(context.state.estimatedDeliveryTime)
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          Spacer()
+          Image(systemName: statusIcon(for: context.state.status))
+            .font(.title)
+            .foregroundColor(.orange)
+        }
+      }
+      .padding()
+      .background(Color(.systemBackground))
+    } dynamicIsland: { context in
+      DynamicIsland {
+        DynamicIslandExpandedRegion(.leading) {
+          Image(systemName: "bag.fill")
+            .foregroundColor(.orange)
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          Image(systemName: statusIcon(for: context.state.status))
+            .foregroundColor(.orange)
+        }
+        DynamicIslandExpandedRegion(.center) {
+          Text(context.attributes.restaurantName)
+            .font(.headline)
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+          VStack(spacing: 4) {
+            Text(context.state.status)
+              .font(.subheadline)
+            Text(context.state.estimatedDeliveryTime)
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+      } compactLeading: {
+        Image(systemName: "bag.fill")
+          .foregroundColor(.orange)
+      } compactTrailing: {
+        Text(context.state.estimatedDeliveryTime)
+          .font(.caption)
+      } minimal: {
+        Image(systemName: "bag.fill")
+          .foregroundColor(.orange)
+      }
+    }
+  }
+
+  private func statusIcon(for status: String) -> String {
+    switch status {
+    case "Preparing":
+      return "flame.fill"
+    case "On the way":
+      return "car.fill"
+    case "Delivered":
+      return "checkmark.circle.fill"
+    default:
+      return "clock.fill"
+    }
+  }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidgetBundle.swift
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct DeliveryLiveActivityWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    DeliveryLiveActivityWidget()
+  }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidgetControl.swift
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidgetControl.swift
@@ -1,0 +1,54 @@
+//
+//  DeliveryLiveActivityWidgetControl.swift
+//  DeliveryLiveActivityWidget
+//
+//  Created by Hyeonji Shin on 1/13/26.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct DeliveryLiveActivityWidgetControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: "so.clix.samples.basic.DeliveryLiveActivityWidget",
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value,
+                action: StartTimerIntent()
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension DeliveryLiveActivityWidgetControl {
+    struct Provider: ControlValueProvider {
+        var previewValue: Bool {
+            false
+        }
+
+        func currentValue() async throws -> Bool {
+            let isRunning = true // Check if the timer is running
+            return isRunning
+        }
+    }
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    func perform() async throws -> some IntentResult {
+        // Start / stop the timer based on `value`.
+        return .result()
+    }
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidgetLiveActivity.swift
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/DeliveryLiveActivityWidgetLiveActivity.swift
@@ -1,0 +1,80 @@
+//
+//  DeliveryLiveActivityWidgetLiveActivity.swift
+//  DeliveryLiveActivityWidget
+//
+//  Created by Hyeonji Shin on 1/13/26.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct DeliveryLiveActivityWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var emoji: String
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+struct DeliveryLiveActivityWidgetLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: DeliveryLiveActivityWidgetAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack {
+                Text("Hello \(context.state.emoji)")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("Leading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Trailing")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("Bottom \(context.state.emoji)")
+                    // more content
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T \(context.state.emoji)")
+            } minimal: {
+                Text(context.state.emoji)
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+extension DeliveryLiveActivityWidgetAttributes {
+    fileprivate static var preview: DeliveryLiveActivityWidgetAttributes {
+        DeliveryLiveActivityWidgetAttributes(name: "World")
+    }
+}
+
+extension DeliveryLiveActivityWidgetAttributes.ContentState {
+    fileprivate static var smiley: DeliveryLiveActivityWidgetAttributes.ContentState {
+        DeliveryLiveActivityWidgetAttributes.ContentState(emoji: "😀")
+     }
+     
+     fileprivate static var starEyes: DeliveryLiveActivityWidgetAttributes.ContentState {
+         DeliveryLiveActivityWidgetAttributes.ContentState(emoji: "🤩")
+     }
+}
+
+#Preview("Notification", as: .content, using: DeliveryLiveActivityWidgetAttributes.preview) {
+   DeliveryLiveActivityWidgetLiveActivity()
+} contentStates: {
+    DeliveryLiveActivityWidgetAttributes.ContentState.smiley
+    DeliveryLiveActivityWidgetAttributes.ContentState.starEyes
+}

--- a/Samples/BasicApp/DeliveryLiveActivityWidget/Info.plist
+++ b/Samples/BasicApp/DeliveryLiveActivityWidget/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+</dict>
+</plist>

--- a/Samples/BasicApp/Sources/AppDelegate.swift
+++ b/Samples/BasicApp/Sources/AppDelegate.swift
@@ -1,3 +1,4 @@
+import ActivityKit
 import Clix
 import FirebaseCore
 import FirebaseMessaging
@@ -14,6 +15,9 @@ class AppDelegate: ClixAppDelegate {
   ) -> Bool {
     FirebaseApp.configure()
     Clix.initialize(config: ClixConfiguration.shared.config)
+    if #available(iOS 16.1, *) {
+        Clix.LiveActivity.setup(DeliveryActivityAttributes.self)
+    }
     updateClixValues()
 
     if let savedUserId = UserDefaults.standard.string(forKey: "user_id"), !savedUserId.isEmpty {
@@ -54,8 +58,6 @@ class AppDelegate: ClixAppDelegate {
     print("🔄 APNS Token received and processed")
     updateClixValues()
   }
-
-  
 
   private func updateClixValues() {
     Task {

--- a/Samples/BasicApp/Sources/ContentView.swift
+++ b/Samples/BasicApp/Sources/ContentView.swift
@@ -67,7 +67,6 @@ struct ContentView: View {
             Button(
               action: {
                 if !userIdInput.isEmpty {
-                  // Save user_id to UserDefaults
                   UserDefaults.standard.set(userIdInput, forKey: "user_id")
                   Clix.setUserId(userIdInput)
                   alertMessage = "User ID set!"
@@ -128,7 +127,6 @@ struct ContentView: View {
                 alertMessage = "User property '\(userPropertyKeyInput): \(userPropertyValueInput)' set successfully"
                 showAlert = true
 
-                // Clear inputs after successful set
                 userPropertyKeyInput = ""
                 userPropertyValueInput = ""
               },
@@ -220,6 +218,12 @@ struct ContentView: View {
             .background(AppTheme.buttonBackground)
             .cornerRadius(12)
           }
+
+          Spacer().frame(height: 32)
+
+          if #available(iOS 16.2, *) {
+            LiveActivitySection()
+          }
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 32)
@@ -232,6 +236,59 @@ struct ContentView: View {
     .background(AppTheme.background.ignoresSafeArea())
     .alert(isPresented: $showAlert) {
       Alert(title: Text(alertMessage))
+    }
+  }
+}
+
+@available(iOS 16.2, *)
+struct LiveActivitySection: View {
+  @ObservedObject private var manager = LiveActivityManager.shared
+  @State private var deliveryStatus: String = "Preparing"
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Live Activity")
+        .font(.headline)
+        .foregroundColor(AppTheme.text)
+
+      if !manager.isActive {
+        Button(action: { manager.start() }) {
+          Text("Start Live Activity")
+            .fontWeight(.bold)
+            .foregroundColor(AppTheme.buttonText)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+        }
+        .background(AppTheme.buttonBackground)
+        .cornerRadius(12)
+      } else {
+        Picker("Status", selection: $deliveryStatus) {
+          Text("Preparing").tag("Preparing")
+          Text("On the way").tag("On the way")
+          Text("Delivered").tag("Delivered")
+        }
+        .pickerStyle(SegmentedPickerStyle())
+
+        Button(action: { manager.update(status: deliveryStatus) }) {
+          Text("Update Status")
+            .fontWeight(.bold)
+            .foregroundColor(AppTheme.buttonText)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+        }
+        .background(AppTheme.buttonBackground)
+        .cornerRadius(12)
+
+        Button(action: { manager.end() }) {
+          Text("End Live Activity")
+            .fontWeight(.bold)
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+        }
+        .background(Color.red)
+        .cornerRadius(12)
+      }
     }
   }
 }

--- a/Samples/BasicApp/Sources/DeliveryActivityAttributes.swift
+++ b/Samples/BasicApp/Sources/DeliveryActivityAttributes.swift
@@ -1,0 +1,12 @@
+import ActivityKit
+import Foundation
+
+struct DeliveryActivityAttributes: ActivityAttributes {
+  public struct ContentState: Codable, Hashable {
+    var status: String
+    var estimatedDeliveryTime: String
+  }
+
+  var orderNumber: String
+  var restaurantName: String
+}

--- a/Samples/BasicApp/Sources/LiveActivityManager.swift
+++ b/Samples/BasicApp/Sources/LiveActivityManager.swift
@@ -1,0 +1,76 @@
+import ActivityKit
+import Foundation
+
+@available(iOS 16.2, *)
+@MainActor
+class LiveActivityManager: ObservableObject {
+  static let shared = LiveActivityManager()
+
+  @Published var isActive: Bool = false
+  private var currentActivity: Activity<DeliveryActivityAttributes>?
+
+  private init() {}
+
+  func start() {
+    let attributes = DeliveryActivityAttributes(
+      orderNumber: String(Int.random(in: 1000...9999)),
+      restaurantName: "Pizza Palace"
+    )
+    let contentState = DeliveryActivityAttributes.ContentState(
+      status: "Preparing",
+      estimatedDeliveryTime: "30-40 min"
+    )
+
+    do {
+      let activity = try Activity<DeliveryActivityAttributes>.request(
+        attributes: attributes,
+        content: .init(state: contentState, staleDate: nil),
+        pushType: .token
+      )
+      currentActivity = activity
+      isActive = true
+      print("Live Activity started: \(activity.id)")
+    } catch {
+      print("Failed to start Live Activity: \(error)")
+    }
+  }
+
+  func update(status: String) {
+    guard let activity = currentActivity else { return }
+
+    let estimatedTime: String
+    switch status {
+    case "Preparing":
+      estimatedTime = "30-40 min"
+    case "On the way":
+      estimatedTime = "10-15 min"
+    case "Delivered":
+      estimatedTime = "Arrived!"
+    default:
+      estimatedTime = "Unknown"
+    }
+
+    let contentState = DeliveryActivityAttributes.ContentState(
+      status: status,
+      estimatedDeliveryTime: estimatedTime
+    )
+
+    Task {
+      await activity.update(ActivityContent(state: contentState, staleDate: nil))
+      print("Live Activity updated: \(status)")
+    }
+  }
+
+  func end() {
+    guard let activity = currentActivity else { return }
+
+    Task {
+      await activity.end(nil, dismissalPolicy: .immediate)
+      await MainActor.run {
+        currentActivity = nil
+        isActive = false
+      }
+      print("Live Activity ended")
+    }
+  }
+}

--- a/Sources/Core/Clix.swift
+++ b/Sources/Core/Clix.swift
@@ -75,6 +75,9 @@ public final class Clix {
 
   #if !APPLICATION_EXTENSION_API_ONLY
     public static let Notification = ClixNotification.shared
+
+    @available(iOS 16.1, *)
+    public static let LiveActivity = ClixLiveActivity.shared
   #endif
 
   // MARK: - Storage Keys

--- a/Sources/Core/ClixLiveActivity.swift
+++ b/Sources/Core/ClixLiveActivity.swift
@@ -1,0 +1,19 @@
+import ActivityKit
+import Foundation
+
+@available(iOS 16.1, *)
+@available(iOSApplicationExtension, unavailable)
+public class ClixLiveActivity {
+  public static let shared = ClixLiveActivity()
+
+  private let service = LiveActivityService()
+
+  private init() {}
+
+  /// Starts listening for push-to-start tokens. Requires iOS 17.2+ (checked internally).
+  public func setup<Attributes: ActivityAttributes>(_ activityType: Attributes.Type) {
+    Task {
+      await service.startListeningForPushToStartToken(activityType)
+    }
+  }
+}

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.6.0"
+  internal static let current: String = "1.7.0-beta.1"
 }

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.7.0-beta.1"
+  internal static let current: String = "1.7.0"
 }

--- a/Sources/Services/LiveActivityAPIService.swift
+++ b/Sources/Services/LiveActivityAPIService.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class LiveActivityAPIService: ClixAPIClient {
-  func setPushToStartToken(
+  func registerLiveActivityStartToken(
     deviceId: String,
     activityType: String,
     token: String

--- a/Sources/Services/LiveActivityAPIService.swift
+++ b/Sources/Services/LiveActivityAPIService.swift
@@ -6,8 +6,8 @@ class LiveActivityAPIService: ClixAPIClient {
     activityType: String,
     token: String
   ) async throws {
-    let path = "/devices/\(deviceId)/live-activities/\(activityType)/push-to-start-token"
-    let body = ["token": token]
+    let path = "/devices/\(deviceId)/live-activity-start-tokens"
+    let body = ["attributes_type": activityType, "push_to_start_token": token]
     let _: EmptyResponse = try await post(path: path, data: body)
   }
 }

--- a/Sources/Services/LiveActivityAPIService.swift
+++ b/Sources/Services/LiveActivityAPIService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class LiveActivityAPIService: ClixAPIClient {
+  func setPushToStartToken(
+    deviceId: String,
+    activityType: String,
+    token: String
+  ) async throws {
+    let path = "/devices/\(deviceId)/live-activities/\(activityType)/push-to-start-token"
+    let body = ["token": token]
+    let _: EmptyResponse = try await post(path: path, data: body)
+  }
+}

--- a/Sources/Services/LiveActivityService.swift
+++ b/Sources/Services/LiveActivityService.swift
@@ -49,7 +49,7 @@ actor LiveActivityService {
       let environment = try Clix.shared.get(\.environment)
       let deviceId = environment.getDevice().id
 
-      try await apiService.setPushToStartToken(
+      try await apiService.registerLiveActivityStartToken(
         deviceId: deviceId,
         activityType: activityType,
         token: token

--- a/Sources/Services/LiveActivityService.swift
+++ b/Sources/Services/LiveActivityService.swift
@@ -1,0 +1,63 @@
+import ActivityKit
+import Foundation
+
+@available(iOS 16.1, *)
+actor LiveActivityService {
+  private let apiService = LiveActivityAPIService()
+  private var activeListeners: Set<String> = []
+
+  func startListeningForPushToStartToken<Attributes: ActivityAttributes>(
+    _ activityType: Attributes.Type
+  ) async {
+    let activityTypeName = String(describing: Attributes.self)
+
+    guard #available(iOS 17.2, *) else {
+      ClixLogger.debug("pushToStartToken listening requires iOS 17.2+")
+      return
+    }
+
+    guard !activeListeners.contains(activityTypeName) else {
+      ClixLogger.debug("Already listening for pushToStartToken: \(activityTypeName)")
+      return
+    }
+
+    activeListeners.insert(activityTypeName)
+    ClixLogger.debug("Starting pushToStartToken listener: \(activityTypeName)")
+
+    Task {
+      await listenForPushToStartTokenUpdates(activityType)
+    }
+  }
+
+  @available(iOS 17.2, *)
+  private func listenForPushToStartTokenUpdates<Attributes: ActivityAttributes>(
+    _ activityType: Attributes.Type
+  ) async {
+    let activityTypeName = String(describing: Attributes.self)
+
+    for await tokenData in Activity<Attributes>.pushToStartTokenUpdates {
+      let token = tokenData.map { String(format: "%02x", $0) }.joined()
+      ClixLogger.debug("Received pushToStartToken for \(activityTypeName): \(token)")
+      await sendPushToStartToken(token, activityType: activityTypeName)
+    }
+  }
+
+  private func sendPushToStartToken(_ token: String, activityType: String) async {
+    do {
+      await Clix.shared.initCoordinator.waitForInitialization()
+
+      let environment = try Clix.shared.get(\.environment)
+      let deviceId = environment.getDevice().id
+
+      try await apiService.setPushToStartToken(
+        deviceId: deviceId,
+        activityType: activityType,
+        token: token
+      )
+
+      ClixLogger.debug("Sent pushToStartToken for \(activityType)")
+    } catch {
+      ClixLogger.error("Failed to send pushToStartToken for \(activityType): \(error)")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added Live Activity framework integration with push-to-start token support (iOS 17.2+)
- Implemented ClixLiveActivity singleton and LiveActivityService for token listening and API sync
- Added comprehensive sample app demo with delivery tracking UI for lock screen and Dynamic Island
- Integrated push token collection into existing SDK initialization flow

## Test Plan
- [x] Sample app compiles and runs on iOS 16.1+
- [x] Live Activity can be started/updated/ended from sample UI
- [x] push-to-start tokens are collected on iOS 17.2+ devices
- [x] API calls correctly include project authentication headers

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live Activities support for real-time delivery tracking (lock screen, Dynamic Island) with dedicated delivery widget and updated app icons/assets.
  * In-app controls to start, update, and end live activity tracking; remote "push-to-start" token handling for server-initiated activities.

* **Chores**
  * SDK version bumped to 1.7.0 and release notes updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->