### PR TITLE
feat(core): make SDK initialization single-flight safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Package.resolved
 GoogleService-Info.plist
 ClixConfig.json
 Pods
+# Local sample environment configs
+ClixConfig.*.json

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,5 +57,6 @@ excluded:
   - .build
   - .swiftpm
   - Sources/Utils/AnyCodable
+  - Samples/CocoaPods/Pods
   - Samples/BasicApp/.build
 reporter: "xcode" 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Swift code formatting and linting
 
 # Define phony targets to avoid conflicts with files named format or lint
-.PHONY: build clean format lint lint-fix all
+.PHONY: build test clean format lint lint-fix all
 
 # Target to build the Swift package for iOS devices
 build:
@@ -12,6 +12,18 @@ build:
         -Xswiftc $(shell xcrun --sdk iphoneos --show-sdk-path) \
         -Xcc -isysroot \
         -Xcc $(shell xcrun --sdk iphoneos --show-sdk-path)
+
+# Detect first available iPhone Simulator UDID
+SIMULATOR_UDID := $(shell xcrun simctl list devices available | grep iPhone | head -1 | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}')
+
+# Target to run tests on iOS Simulator
+test:
+	@echo "Running tests on iOS Simulator ($(SIMULATOR_UDID))..."
+	@xcodebuild test \
+        -workspace .swiftpm/xcode/package.xcworkspace \
+        -scheme Clix \
+        -destination 'id=$(SIMULATOR_UDID)' \
+        -quiet
 
 # Clean build artifacts and caches
 clean:

--- a/Tests/ClixTests.swift
+++ b/Tests/ClixTests.swift
@@ -2,7 +2,52 @@ import XCTest
 @testable import Clix
 
 final class ClixTests: XCTestCase {
-  func testExample() throws {
-    // This is an example test case
+  actor Counter {
+    private var value = 0
+
+    func increment() {
+      value += 1
+    }
+
+    func currentValue() -> Int {
+      value
+    }
+  }
+
+  func testInitCoordinatorRunsSingleFlightOperationOnce() async {
+    let coordinator = Clix.InitCoordinator()
+    let counter = Counter()
+
+    let firstTask = await coordinator.acquireInitializationTask {
+      try? await Task.sleep(nanoseconds: 100_000_000)
+      await counter.increment()
+    }
+    let secondTask = await coordinator.acquireInitializationTask {
+      await counter.increment()
+    }
+
+    await firstTask.value
+    await secondTask.value
+
+    let value = await counter.currentValue()
+    XCTAssertEqual(value, 1)
+  }
+
+  func testInitCoordinatorAllowsNewOperationAfterCompletion() async {
+    let coordinator = Clix.InitCoordinator()
+    let counter = Counter()
+
+    let firstTask = await coordinator.acquireInitializationTask {
+      await counter.increment()
+    }
+    await firstTask.value
+
+    let secondTask = await coordinator.acquireInitializationTask {
+      await counter.increment()
+    }
+    await secondTask.value
+
+    let value = await counter.currentValue()
+    XCTAssertEqual(value, 2)
   }
 }


### PR DESCRIPTION
## Summary
- make async `Clix.initialize(config:)` single-flight by reusing one actor-managed task
- ensure initialization completion is always signaled, even when setup throws
- add concurrency tests for `InitCoordinator` single-flight and rerun behavior
- add `make test` target for iOS simulator, update SwiftLint exclusions, and add BasicApp env config JSON files

## Why
Concurrent initialization calls could start duplicated setup work. This change ensures all callers await the same in-flight initialization task and improves deterministic initialization behavior.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow/CI

## Testing
- [x] `make test` (iOS Simulator) passed
- [ ] `swift test` (not applicable in this environment due to macOS dependency constraints)

## Risk / Impact
- low to medium: initialization flow changed to task-coalescing behavior
- covered by new unit tests around coordinator task lifecycle

## Related Issue
- #XXXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for initialization coordination to ensure proper single-flight operation behavior and task management.

* **Chores**
  * Updated build configuration to support automated testing on iOS Simulator.
  * Updated linting exclusions and ignore patterns for project maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->