### PR TITLE
feat: add session tracking

### DIFF
--- a/Sources/Core/Clix.swift
+++ b/Sources/Core/Clix.swift
@@ -91,6 +91,7 @@ public final class Clix {
   var deviceService: DeviceService?
   var notificationService: NotificationService?
   var sessionService: SessionService?
+  var pendingLaunchMessageId: String?
 
   // MARK: - Initialization Coordinator
   internal let initCoordinator = InitCoordinator()
@@ -176,6 +177,10 @@ public final class Clix {
       #if !APPLICATION_EXTENSION_API_ONLY
         ClixNotification.shared.initialize()
         shared.sessionService?.setupLifecycleObservers()
+        if let messageId = shared.pendingLaunchMessageId {
+          shared.sessionService?.setPendingMessageId(messageId)
+          shared.pendingLaunchMessageId = nil
+        }
         await shared.sessionService?.start()
       #endif
       await shared.initCoordinator.completeInitialization()

--- a/Sources/Core/Clix.swift
+++ b/Sources/Core/Clix.swift
@@ -176,9 +176,8 @@ public final class Clix {
       #if !APPLICATION_EXTENSION_API_ONLY
         ClixNotification.shared.initialize()
         shared.sessionService?.setupLifecycleObservers()
+        await shared.sessionService?.start()
       #endif
-
-      await shared.sessionService?.start()
       await shared.initCoordinator.completeInitialization()
     } catch {
       ClixLogger.error("Failed to initialize Clix SDK: \(error)")

--- a/Sources/Core/Clix.swift
+++ b/Sources/Core/Clix.swift
@@ -90,6 +90,7 @@ public final class Clix {
   var eventService: EventService?
   var deviceService: DeviceService?
   var notificationService: NotificationService?
+  var sessionService: SessionService?
 
   // MARK: - Initialization Coordinator
   internal let initCoordinator = InitCoordinator()
@@ -118,6 +119,11 @@ public final class Clix {
 
     self.deviceService = DeviceService(storageService: storageService, tokenService: tokenService)
     self.notificationService = NotificationService(storageService: storageService, eventService: eventService)
+    self.sessionService = SessionService(
+      storageService: storageService,
+      eventService: eventService,
+      sessionTimeoutMs: config.sessionTimeoutMs
+    )
   }
 
   // MARK: - Internal Methods
@@ -169,8 +175,10 @@ public final class Clix {
 
       #if !APPLICATION_EXTENSION_API_ONLY
         ClixNotification.shared.initialize()
+        shared.sessionService?.setupLifecycleObservers()
       #endif
 
+      await shared.sessionService?.start()
       await shared.initCoordinator.completeInitialization()
     } catch {
       ClixLogger.error("Failed to initialize Clix SDK: \(error)")

--- a/Sources/Core/ClixConfig.swift
+++ b/Sources/Core/ClixConfig.swift
@@ -7,6 +7,7 @@ public struct ClixConfig: Codable {
   let endpoint: String
   let logLevel: ClixLogLevel
   let extraHeaders: [String: String]
+  let sessionTimeoutMs: Int
 
   /// Initialize ClixConfig
   /// - Parameters:
@@ -15,17 +16,30 @@ public struct ClixConfig: Codable {
   ///   - endpoint: Clix API endpoint URL (default: "https://api.clix.so")
   ///   - logLevel: Logging level (default: .info)
   ///   - extraHeaders: Extra headers for API requests (default: [:])
+  ///   - sessionTimeoutMs: Session timeout in milliseconds (default: 30000, minimum: 5000)
   public init(
     projectId: String = "",
     apiKey: String = "",
     endpoint: String = "https://api.clix.so",
     logLevel: ClixLogLevel = .info,
-    extraHeaders: [String: String] = [:]
+    extraHeaders: [String: String] = [:],
+    sessionTimeoutMs: Int = 30_000
   ) {
     self.projectId = projectId
     self.apiKey = apiKey
     self.endpoint = endpoint
     self.logLevel = logLevel
     self.extraHeaders = extraHeaders
+    self.sessionTimeoutMs = sessionTimeoutMs
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    projectId = try container.decode(String.self, forKey: .projectId)
+    apiKey = try container.decode(String.self, forKey: .apiKey)
+    endpoint = try container.decode(String.self, forKey: .endpoint)
+    logLevel = try container.decode(ClixLogLevel.self, forKey: .logLevel)
+    extraHeaders = try container.decode([String: String].self, forKey: .extraHeaders)
+    sessionTimeoutMs = try container.decodeIfPresent(Int.self, forKey: .sessionTimeoutMs) ?? 30_000
   }
 }

--- a/Sources/Core/ClixNotification.swift
+++ b/Sources/Core/ClixNotification.swift
@@ -61,6 +61,7 @@ public class ClixNotification: NSObject, UNUserNotificationCenterDelegate, Messa
       let messageId = extractMessageId(from: payload)
       if let messageId = messageId {
         processedTappedEvents.insert(messageId)
+        Clix.shared.sessionService?.setPendingMessageId(messageId)
       }
 
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -247,6 +248,7 @@ public class ClixNotification: NSObject, UNUserNotificationCenterDelegate, Messa
         return
       }
       processedTappedEvents.insert(messageId)
+      Clix.shared.sessionService?.setPendingMessageId(messageId)
     }
 
     if let handler = openedHandler { handler(userInfo) }

--- a/Sources/Core/ClixNotification.swift
+++ b/Sources/Core/ClixNotification.swift
@@ -61,7 +61,7 @@ public class ClixNotification: NSObject, UNUserNotificationCenterDelegate, Messa
       let messageId = extractMessageId(from: payload)
       if let messageId = messageId {
         processedTappedEvents.insert(messageId)
-        Clix.shared.sessionService?.setPendingMessageId(messageId)
+        Clix.shared.pendingLaunchMessageId = messageId
       }
 
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/Sources/Services/SessionService.swift
+++ b/Sources/Services/SessionService.swift
@@ -1,0 +1,91 @@
+import Foundation
+#if !APPLICATION_EXTENSION_API_ONLY
+  import UIKit
+#endif
+
+enum SessionEvent: String {
+  case sessionStart = "SESSION_START"
+}
+
+class SessionService {
+  private static let lastActivityKey = "clix_session_last_activity"
+
+  private let storageService: StorageService
+  private let eventService: EventService
+  private let sessionTimeoutMs: Int
+  private var pendingMessageId: String?
+
+  init(storageService: StorageService, eventService: EventService, sessionTimeoutMs: Int) {
+    self.storageService = storageService
+    self.eventService = eventService
+    self.sessionTimeoutMs = max(sessionTimeoutMs, 5000)
+  }
+
+  func start() async {
+    let lastActivity: Double? = await storageService.get(Self.lastActivityKey)
+    if let lastActivity {
+      let elapsed = Date().timeIntervalSince1970 * 1000 - lastActivity
+      if elapsed <= Double(sessionTimeoutMs) {
+        await updateLastActivity()
+        ClixLogger.debug("Continuing existing session")
+        return
+      }
+    }
+    await startNewSession()
+  }
+
+  #if !APPLICATION_EXTENSION_API_ONLY
+    func setupLifecycleObservers() {
+      NotificationCenter.default.addObserver(
+        forName: UIApplication.willEnterForegroundNotification,
+        object: nil, queue: .main
+      ) { [weak self] _ in
+        Task { await self?.handleForeground() }
+      }
+      NotificationCenter.default.addObserver(
+        forName: UIApplication.didEnterBackgroundNotification,
+        object: nil, queue: .main
+      ) { [weak self] _ in
+        Task { await self?.updateLastActivity() }
+      }
+    }
+  #endif
+
+  func setPendingMessageId(_ messageId: String?) {
+    pendingMessageId = messageId
+  }
+
+  // MARK: - Private
+
+  private func handleForeground() async {
+    let lastActivity: Double? = await storageService.get(Self.lastActivityKey)
+    if let lastActivity {
+      let elapsed = Date().timeIntervalSince1970 * 1000 - lastActivity
+      if elapsed <= Double(sessionTimeoutMs) {
+        await updateLastActivity()
+        return
+      }
+    }
+    await startNewSession()
+  }
+
+  private func startNewSession() async {
+    let messageId = pendingMessageId
+    pendingMessageId = nil
+    await updateLastActivity()
+
+    do {
+      try await eventService.trackEvent(
+        name: SessionEvent.sessionStart.rawValue,
+        messageId: messageId
+      )
+      ClixLogger.debug("\(SessionEvent.sessionStart.rawValue) tracked")
+    } catch {
+      ClixLogger.error("Failed to track \(SessionEvent.sessionStart.rawValue): \(error)")
+    }
+  }
+
+  private func updateLastActivity() async {
+    await storageService.set(Self.lastActivityKey, Date().timeIntervalSince1970 * 1000)
+  }
+}

--- a/Sources/Storage/StorageMigrator.swift
+++ b/Sources/Storage/StorageMigrator.swift
@@ -13,6 +13,7 @@ struct StorageMigrator {
     "clix_push_tokens",
     "clix_notification_settings",
     "clix_last_received_message_id",
+    "clix_session_last_activity",
   ]
 
   static func migrateKeys<Source, Destination>(


### PR DESCRIPTION
### Summary
- Add `SessionService` that tracks `SESSION_START` events based on app lifecycle (foreground/background) with configurable timeout
- Add `sessionTimeoutMs` to `ClixConfig` (default: 30s, minimum: 5s)
- Set `pendingMessageId` on push notification tap so the subsequent `SESSION_START` event includes the `messageId`
- Add `clix_session_last_activity` to `StorageMigrator` known keys

### Changes
- **New**: `Sources/Services/SessionService.swift` — session timeout logic, lifecycle observers, `SessionEvent` enum
- **Modified**: `Sources/Core/Clix.swift` — initialize and start `SessionService`
- **Modified**: `Sources/Core/ClixConfig.swift` — add `sessionTimeoutMs` with backward-compatible `Codable` support
- **Modified**: `Sources/Core/ClixNotification.swift` — call `setPendingMessageId` on notification tap
- **Modified**: `Sources/Storage/StorageMigrator.swift` — register `clix_session_last_activity` key

### Spec
- https://www.notion.so/greyboxhq/Tech-Clix-Session-3031f02665f180dfa04bc91a836f0889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable session timeout (default: 30 seconds).
  * Session persistence and automatic recovery to maintain user session across app background/foreground transitions.
  * Improved notification handling so tapped or launch notifications are tracked and correlated with sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->