### PR TITLE
feat: add sourceType to event tracking

### DIFF
--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.8.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.8.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clix iOS SDK is a powerful tool for managing push notifications and user events 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.8.0")
+    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.8.1")
 ]
 ```
 

--- a/Samples/BasicApp/BasicApp.xcodeproj/project.pbxproj
+++ b/Samples/BasicApp/BasicApp.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		7FADBC0C2F15FA9C0065D721 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7FADBC0B2F15FA9C0065D721 /* SwiftUI.framework */; };
 		7FADBC1B2F15FA9D0065D721 /* DeliveryLiveActivityWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7FADBC082F15FA9B0065D721 /* DeliveryLiveActivityWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7FADBC262F15FD6A0065D721 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7FADBC252F15FD6A0065D721 /* GoogleService-Info.plist */; };
-		7FADBC282F15FD790065D721 /* ClixConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 7FADBC272F15FD790065D721 /* ClixConfig.json */; };
 		88C976AF2DE72BA500D410F8 /* ClixNotificationExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 88C976A82DE72BA500D410F8 /* ClixNotificationExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		88C976B82DE7426200D410F8 /* Clix in Frameworks */ = {isa = PBXBuildFile; productRef = 88C976B72DE7426200D410F8 /* Clix */; };
 /* End PBXBuildFile section */
@@ -57,7 +56,6 @@
 		7FADBC092F15FA9B0065D721 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		7FADBC0B2F15FA9C0065D721 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		7FADBC252F15FD6A0065D721 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		7FADBC272F15FD790065D721 /* ClixConfig.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ClixConfig.json; sourceTree = "<group>"; };
 		88C976A82DE72BA500D410F8 /* ClixNotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ClixNotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -157,7 +155,6 @@
 		48F08EBC2DDF90CC003D26D4 = {
 			isa = PBXGroup;
 			children = (
-				7FADBC272F15FD790065D721 /* ClixConfig.json */,
 				7FADBC252F15FD6A0065D721 /* GoogleService-Info.plist */,
 				489A1DF02DF6B864005D66F7 /* Resources */,
 				48533B3E2DE437020060D148 /* BasicApp-Info.plist */,
@@ -315,7 +312,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7FADBC262F15FD6A0065D721 /* GoogleService-Info.plist in Resources */,
-				7FADBC282F15FD790065D721 /* ClixConfig.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.8.0"
+  internal static let current: String = "1.8.1"
 }

--- a/Sources/Services/EventAPIService.swift
+++ b/Sources/Services/EventAPIService.swift
@@ -3,6 +3,7 @@ import Foundation
 struct EventRequestBody: Codable {
   let deviceId: String
   let name: String
+  let sourceType: String?
   let properties: [String: AnyCodable]  // expects ["custom_properties": ...]
 }
 
@@ -24,13 +25,15 @@ class EventAPIService: ClixAPIClient {
     properties: [String: AnyCodable]? = nil,
     messageId: String? = nil,
     userJourneyId: String? = nil,
-    userJourneyNodeId: String? = nil
+    userJourneyNodeId: String? = nil,
+    sourceType: String? = nil
   )
     async throws
   {
     let event = EventRequestBody(
       deviceId: deviceId,
       name: name,
+      sourceType: sourceType,
       properties: [
         "custom_properties": AnyCodable(properties ?? [:]), "message_id": AnyCodable(messageId),
         "user_journey_id": AnyCodable(userJourneyId), "user_journey_node_id": AnyCodable(userJourneyNodeId),

--- a/Sources/Services/EventService.swift
+++ b/Sources/Services/EventService.swift
@@ -13,7 +13,8 @@ class EventService {
     properties: [String: Any?] = [:],
     messageId: String? = nil,
     userJourneyId: String? = nil,
-    userJourneyNodeId: String? = nil
+    userJourneyNodeId: String? = nil,
+    sourceType: String? = nil
   ) async throws {
     do {
       let environment = try Clix.shared.get(\.environment)
@@ -41,7 +42,8 @@ class EventService {
         properties: eventProperties,
         messageId: messageId,
         userJourneyId: userJourneyId,
-        userJourneyNodeId: userJourneyNodeId
+        userJourneyNodeId: userJourneyNodeId,
+        sourceType: sourceType
       )
     } catch {
       ClixLogger.error("Failed to track event '\(name)': \(error). Make sure Clix.initialize() has been called.")

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -44,7 +44,8 @@ class NotificationService {
           name: NotificationEvent.pushNotificationReceived.rawValue,
           messageId: payload.messageId,
           userJourneyId: payload.userJourneyId,
-          userJourneyNodeId: payload.userJourneyNodeId
+          userJourneyNodeId: payload.userJourneyNodeId,
+          sourceType: "CLIX"
         )
       } catch {
         await recoverReceivedMessageId(messageId: payload.messageId)
@@ -65,7 +66,8 @@ class NotificationService {
           name: NotificationEvent.pushNotificationTapped.rawValue,
           messageId: payload.messageId,
           userJourneyId: payload.userJourneyId,
-          userJourneyNodeId: payload.userJourneyNodeId
+          userJourneyNodeId: payload.userJourneyNodeId,
+          sourceType: "CLIX"
         )
       } catch {
         ClixLogger.error("Failed to track \(NotificationEvent.pushNotificationTapped.rawValue)", error: error)

--- a/Sources/Services/SessionService.swift
+++ b/Sources/Services/SessionService.swift
@@ -79,7 +79,8 @@ class SessionService {
     do {
       try await eventService.trackEvent(
         name: SessionEvent.sessionStart.rawValue,
-        messageId: messageId
+        messageId: messageId,
+        sourceType: "CLIX"
       )
       ClixLogger.debug("\(SessionEvent.sessionStart.rawValue) tracked")
     } catch {


### PR DESCRIPTION
## Summary
- SESSION_START, PUSH_NOTIFICATION_RECEIVED, PUSH_NOTIFICATION_TAPPED 이벤트에 `sourceType: "CLIX"` 추가
- EventService, EventAPIService에 `sourceType` 파라미터 추가 (기본값 nil, 브레이킹 체인지 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event tracking now accepts an optional source type, and push events (received/tapped) plus session-start events include source type metadata for richer analytics.

* **Chores**
  * Release bumped to 1.8.1 (package references and internal version updated).
  * Sample app project cleaned up to remove an obsolete config resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->