### PR TITLE
feat: add reset() and deprecate removeUserId()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-02-19
+
+### Added
+
+- `reset()` method to clear all local SDK state including device ID
+
+### Changed
+
+- `setUserId()` now accepts nil to remove the user ID
+
+### Deprecated
+
+- `removeUserId()` — use `setUserId(nil)` instead
+
 ## [1.8.1] - 2026-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `reset()` method to clear all local SDK state including device ID
 
-### Changed
-
-- `setUserId()` now accepts nil to remove the user ID
-
 ### Deprecated
 
-- `removeUserId()` — use `setUserId(nil)` instead
+- `removeUserId()` — use `reset()` instead
 
 ## [1.8.1] - 2026-02-13
 

--- a/Clix.podspec
+++ b/Clix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Clix'
   # Don't modify below line - it's automatically updated by scripts/update-version.sh
-  spec.version          = '1.8.1' # Don't modify this line - it's automatically updated by scripts/update-version.sh
+  spec.version          = '1.9.0' # Don't modify this line - it's automatically updated by scripts/update-version.sh
   spec.summary          = 'Clix iOS SDK for push notifications and analytics'
   spec.description      = <<-DESC
 Clix iOS SDK provides push notification and analytics capabilities for iOS apps.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clix iOS SDK is a powerful tool for managing push notifications and user events 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.8.1")
+    .package(url: "https://github.com/clix-so/clix-ios-sdk.git", from: "1.9.0")
 ]
 ```
 

--- a/Sources/Core/Clix.swift
+++ b/Sources/Core/Clix.swift
@@ -242,30 +242,46 @@ public final class Clix {
     }
   }
 
-  /// Removes the user ID (async version - recommended)
-  ///
-  /// This async version ensures the operation completes before returning.
-  /// Use this when you can await the operation in an async context.
-  ///
-  /// - Throws: ClixError if the operation fails
+  /// Removes the user ID (async version)
+  @available(*, deprecated, message: "Use reset() instead")
   public static func removeUserId() async throws {
     await shared.initCoordinator.waitForInitialization()
     try await shared.get(\.deviceService).removeProjectUserId()
   }
 
   /// Removes the user ID (synchronous version)
-  ///
-  /// This synchronous version returns immediately while the operation continues in the background.
-  /// Consider using the async version for guaranteed operation completion.
-  ///
-  /// - Note: An async version is available that ensures the operation completes before returning.
-  ///         Use `try await Clix.removeUserId()` for better control over operation timing.
+  @available(*, deprecated, message: "Use reset() instead")
   public static func removeUserId() {
     Task.detached(priority: .userInitiated) {
       do {
         try await removeUserId()
       } catch {
         ClixLogger.error("Failed to remove userId: \(error)")
+      }
+    }
+  }
+
+  /// Resets all local SDK state including device ID.
+  ///
+  /// After calling this method, you must call `initialize()` again before using the SDK.
+  /// Use this when a user logs out and you want to start fresh with a new device identity.
+  public static func reset() async throws {
+    await shared.initCoordinator.waitForInitialization()
+    let notificationService = try shared.get(\.notificationService)
+    let storageService = try shared.get(\.storageService)
+    await notificationService.reset()
+    await storageService.remove("clix_device_id")
+    await storageService.remove("clix_session_last_activity")
+    await shared.initCoordinator.reset()
+  }
+
+  /// Resets all local SDK state including device ID (synchronous version)
+  public static func reset() {
+    Task.detached(priority: .userInitiated) {
+      do {
+        try await reset()
+      } catch {
+        ClixLogger.error("Failed to reset: \(error)")
       }
     }
   }
@@ -522,6 +538,10 @@ public final class Clix {
       for continuation in continuations {
         continuation.resume()
       }
+    }
+
+    internal func reset() {
+      isInitialized = false
     }
 
     nonisolated internal func waitAndGet<T>(_ getter: @escaping () -> T?) -> T? {

--- a/Sources/Core/ClixVersion.swift
+++ b/Sources/Core/ClixVersion.swift
@@ -2,5 +2,5 @@ import Foundation
 
 internal struct ClixVersion {
   // Don't modify below line - it's automatically updated by scripts/update-version.sh
-  internal static let current: String = "1.8.1"
+  internal static let current: String = "1.9.0"
 }


### PR DESCRIPTION
## Summary
Add `reset()` method for logout support and deprecate `removeUserId()`.

## Changes
- Add `reset()` method that clears all local SDK state (device ID, session) without server calls
- Deprecate `removeUserId()` — use `reset()` instead
- Bump version to 1.9.0

## Spec
https://docs.google.com/document/d/1ET-KqAFQlODNEm08YDXehzfWuqKZsOhnr4NJG-f0P9k/edit?tab=t.0#bookmark=id.9awmqjhnpii6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.9.0

* **New Features**
  * Added reset() method to clear all local SDK state including device ID and session data.

* **Deprecated**
  * removeUserId() method is deprecated; use reset() instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->