### PR TITLE
docs: sync README with latest SDK API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,17 @@ try await Clix.setUserProperties([
 // Remove user properties
 try await Clix.removeUserProperty("name")
 try await Clix.removeUserProperties(["age", "premium"])
-
-// Remove user ID
-try await Clix.removeUserId()
 ```
+
+### Reset
+
+Use `reset()` when you need a completely fresh device identity (e.g., shared device scenarios). This clears all local SDK state and generates a new device ID on next initialization.
+
+```swift
+try await Clix.reset()
+```
+
+> **Note:** After calling `reset()`, you must call `initialize()` again before using the SDK.
 
 ### Event Tracking
 
@@ -104,7 +111,7 @@ try await Clix.trackEvent(
 let deviceId = await Clix.getDeviceId()
 
 // Get push token
-let pushToken = await Clix.getPushToken()
+let pushToken = await Clix.Notification.getToken()
 ```
 
 ### Logging


### PR DESCRIPTION
## 배경

`reset()` API 추가 및 `removeUserId()` deprecated에 따라 README를 최신 SDK API에 맞게 동기화합니다.

## 변경 사항

### User Management
- deprecated된 `removeUserId()` 예제를 User Management 섹션에서 제거

### Reset 섹션 추가
- `Clix.reset()` 사용법과 설명 추가 (새 device ID 생성, user ID 제거, session 데이터 초기화)
- `reset()` 호출 후 반드시 `initialize()`를 다시 호출해야 한다는 안내 포함

### Device Information
- `Clix.getPushToken()` → `Clix.Notification.getToken()`으로 변경 (API 변경 반영)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the reset feature, which clears local state and generates a new device ID; re-initialization required after reset.
  * Updated API documentation for push token retrieval with current method references and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->